### PR TITLE
fix(UART): Refactor RX logic and unify module interface

### DIFF
--- a/rtl/uart_rx.v
+++ b/rtl/uart_rx.v
@@ -1,219 +1,104 @@
 `timescale 1ns/1ps
-// 
-// Module: uart_rx 
-// 
-// Notes:
-// - UART reciever module.
-//
-
 
 module uart_rx(
-input  wire       clk          , // Top level system clock input.
-input  wire       rst_n       , // Asynchronous active low reset.
-input  wire       uart_rxd     , // UART Recieve pin.
-input  wire       uart_rx_en   , // Recieve enable
-input  wire       rx_data_read , // 新增输入端口
-output wire       uart_rx_break, // Did we get a BREAK message?
-output reg        uart_rx_valid, // Valid data recieved and available.--从wire改到reg
-output reg  [PAYLOAD_BITS-1:0] uart_rx_data   // The recieved data.
+    input  wire       clk,
+    input  wire       rst_n, // Corrected from resetn to rst_n for consistency
+    input  wire       uart_rxd,
+    input  wire       uart_rx_en,
+    input  wire       rx_data_read,
+    output wire       uart_rx_break,
+    output reg        uart_rx_valid,
+    output reg  [PAYLOAD_BITS-1:0] uart_rx_data
 );
+    parameter   BIT_RATE        = 9600;
+    parameter   CLK_HZ          = 50_000_000;
+    parameter   PAYLOAD_BITS    = 8;
+    parameter   STOP_BITS       = 1;
+    localparam  BIT_P           = 1_000_000_000 / BIT_RATE;
+    localparam  CLK_P           = 1_000_000_000 / CLK_HZ;
+    localparam  CYCLES_PER_BIT  = BIT_P / CLK_P;
+    localparam  COUNT_REG_LEN   = 1 + $clog2(CYCLES_PER_BIT);
 
-// --------------------------------------------------------------------------- 
-// External parameters.
-// 
+    reg rxd_reg, rxd_reg_0;
+    reg [PAYLOAD_BITS-1:0] recieved_data;
+    reg [COUNT_REG_LEN-1:0] cycle_counter;
+    reg [3:0] bit_counter;
+    reg bit_sample;
+    reg [2:0] fsm_state, n_fsm_state;
 
-//
-// Input bit rate of the UART line.
-parameter   BIT_RATE        = 9600; // bits / sec
-localparam  BIT_P           = 1_000_000_000 * 1/BIT_RATE; // nanoseconds
+    localparam FSM_IDLE = 0, FSM_START= 1, FSM_RECV = 2, FSM_STOP = 3;
 
-//
-// Clock frequency in hertz.
-parameter   CLK_HZ          =    50_000_000;
-localparam  CLK_P           = 1_000_000_000 * 1/CLK_HZ; // nanoseconds
+    assign uart_rx_break = uart_rx_valid && ~|recieved_data;
 
-//
-// Number of data bits recieved per UART packet.
-parameter   PAYLOAD_BITS    = 8;
-
-//
-// Number of stop bits indicating the end of a packet.
-parameter   STOP_BITS       = 1;
-
-// -------------------------------------------------------------------------- 
-// Internal parameters.
-// 
-
-//
-// Number of clock cycles per uart bit.
-localparam       CYCLES_PER_BIT     = BIT_P / CLK_P;
-
-//
-// Size of the registers which store sample counts and bit durations.
-localparam       COUNT_REG_LEN      = 1+$clog2(CYCLES_PER_BIT);
-
-// -------------------------------------------------------------------------- 
-// Internal registers.
-// 
-
-//
-// Internally latched value of the uart_rxd line. Helps break long timing
-// paths from input pins into the logic.
-reg rxd_reg;
-reg rxd_reg_0;
-
-//
-// Storage for the recieved serial data.
-reg [PAYLOAD_BITS-1:0] recieved_data;
-
-//
-// Counter for the number of cycles over a packet bit.
-reg [COUNT_REG_LEN-1:0] cycle_counter;
-
-//
-// Counter for the number of recieved bits of the packet.
-reg [3:0] bit_counter;
-
-//
-// Sample of the UART input line whenever we are in the middle of a bit frame.
-reg bit_sample;
-
-//
-// Current and next states of the internal FSM.
-reg [2:0] fsm_state;
-reg [2:0] n_fsm_state;
-
-localparam FSM_IDLE = 0;
-localparam FSM_START= 1;
-localparam FSM_RECV = 2;
-localparam FSM_STOP = 3;
-
-// --------------------------------------------------------------------------- 
-// Output assignment
-// 
-
-assign uart_rx_break = uart_rx_valid && ~|recieved_data;
-//assign uart_rx_valid = fsm_state == FSM_STOP && n_fsm_state == FSM_IDLE;
-
-always @(posedge clk or negedge rst_n) begin
-    if (!rst_n) begin
-    if(!rst_n) begin
-    if(!rst_n) begin
-    if(!rst_n) begin
-    if(!rst_n) begin
-    if(!rst_n) begin
-    if(!rst_n) begin
-            uart_rx_valid <= 1'b1;         // 拉高 valid 标志
-            uart_rx_data  <= recieved_data;  // 同时锁存数据到输出
-        end 
-        // 当CPU读取数据后
-        else if (rx_data_read) begin
-            uart_rx_valid <= 1'b0;         // 拉低 valid 标志
+    // --- Critical Fix: Corrected Output Logic ---
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            uart_rx_valid <= 1'b0;
+            uart_rx_data  <= {PAYLOAD_BITS{1'b0}};
+        end else begin
+            if (fsm_state == FSM_STOP && n_fsm_state == FSM_IDLE) begin
+                uart_rx_valid <= 1'b1;
+                uart_rx_data  <= recieved_data;
+            end else if (rx_data_read) begin
+                uart_rx_valid <= 1'b0;
+            end
         end
     end
-end
 
-// --------------------------------------------------------------------------- 
-// FSM next state selection.
-// 
+    wire next_bit = cycle_counter == CYCLES_PER_BIT || (fsm_state == FSM_STOP && cycle_counter == CYCLES_PER_BIT/2);
+    wire payload_done = bit_counter == PAYLOAD_BITS;
 
-wire next_bit     = cycle_counter == CYCLES_PER_BIT ||
-                        fsm_state       == FSM_STOP && 
-                        cycle_counter   == CYCLES_PER_BIT/2;
-wire payload_done = bit_counter   == PAYLOAD_BITS  ;
+    always @(*) begin : p_n_fsm_state
+        case(fsm_state)
+            FSM_IDLE : n_fsm_state = rxd_reg ? FSM_IDLE : FSM_START;
+            FSM_START: n_fsm_state = next_bit ? FSM_RECV : FSM_START;
+            FSM_RECV : n_fsm_state = payload_done ? FSM_STOP : FSM_RECV;
+            FSM_STOP : n_fsm_state = next_bit ? FSM_IDLE : FSM_STOP;
+            default  : n_fsm_state = FSM_IDLE;
+        endcase
+    end
 
-//
-// Handle picking the next state.
-always @(*) begin : p_n_fsm_state
-    case(fsm_state)
-        FSM_IDLE : n_fsm_state = rxd_reg      ? FSM_IDLE : FSM_START;
-        FSM_START: n_fsm_state = next_bit     ? FSM_RECV : FSM_START;
-        FSM_RECV : n_fsm_state = payload_done ? FSM_STOP : FSM_RECV ;
-        FSM_STOP : n_fsm_state = next_bit     ? FSM_IDLE : FSM_STOP ;
-        default  : n_fsm_state = FSM_IDLE;
-    endcase
-end
-
-// --------------------------------------------------------------------------- 
-// Internal register setting and re-setting.
-// 
-
-//
-// Handle updates to the recieved data register.
-integer i = 0;
-always @(posedge clk) begin : p_recieved_data
-    if(!resetn) begin
-        recieved_data <= {PAYLOAD_BITS{1'b0}};
-    end else if(fsm_state == FSM_IDLE             ) begin
-        recieved_data <= {PAYLOAD_BITS{1'b0}};
-    end else if(fsm_state == FSM_RECV && next_bit ) begin
-        recieved_data[PAYLOAD_BITS-1] <= bit_sample;
-        for ( i = PAYLOAD_BITS-2; i >= 0; i = i - 1) begin
-            recieved_data[i] <= recieved_data[i+1];
+    integer i = 0;
+    always @(posedge clk) begin : p_recieved_data
+        if(!rst_n) recieved_data <= {PAYLOAD_BITS{1'b0}};
+        else if(fsm_state == FSM_IDLE) recieved_data <= {PAYLOAD_BITS{1'b0}};
+        else if(fsm_state == FSM_RECV && next_bit) begin
+            recieved_data[PAYLOAD_BITS-1] <= bit_sample;
+            for (i = PAYLOAD_BITS-2; i >= 0; i = i - 1) begin
+                recieved_data[i] <= recieved_data[i+1];
+            end
         end
     end
-end
 
-//
-// Increments the bit counter when recieving.
-always @(posedge clk) begin : p_bit_counter
-    if(!resetn) begin
-        bit_counter <= 4'b0;
-    end else if(fsm_state != FSM_RECV) begin
-        bit_counter <= {COUNT_REG_LEN{1'b0}};
-    end else if(fsm_state == FSM_RECV && next_bit) begin
-        bit_counter <= bit_counter + 1'b1;
+    always @(posedge clk) begin : p_bit_counter
+        if(!rst_n) bit_counter <= 4'b0;
+        else if(fsm_state != FSM_RECV) bit_counter <= {COUNT_REG_LEN{1'b0}};
+        else if(fsm_state == FSM_RECV && next_bit) bit_counter <= bit_counter + 1'b1;
     end
-end
 
-//
-// Sample the recieved bit when in the middle of a bit frame.
-always @(posedge clk) begin : p_bit_sample
-    if(!resetn) begin
-        bit_sample <= 1'b0;
-    end else if (cycle_counter == CYCLES_PER_BIT/2) begin
-        bit_sample <= rxd_reg;
+    always @(posedge clk) begin : p_bit_sample
+        if(!rst_n) bit_sample <= 1'b0;
+        else if (cycle_counter == CYCLES_PER_BIT/2) bit_sample <= rxd_reg;
     end
-end
 
-
-//
-// Increments the cycle counter when recieving.
-always @(posedge clk) begin : p_cycle_counter
-    if(!resetn) begin
-        cycle_counter <= {COUNT_REG_LEN{1'b0}};
-    end else if(next_bit) begin
-        cycle_counter <= {COUNT_REG_LEN{1'b0}};
-    end else if(fsm_state == FSM_START || 
-                fsm_state == FSM_RECV  || 
-                fsm_state == FSM_STOP   ) begin
-        cycle_counter <= cycle_counter + 1'b1;
+    always @(posedge clk) begin : p_cycle_counter
+        if(!rst_n) cycle_counter <= {COUNT_REG_LEN{1'b0}};
+        else if(next_bit) cycle_counter <= {COUNT_REG_LEN{1'b0}};
+        else if(fsm_state == FSM_START || fsm_state == FSM_RECV || fsm_state == FSM_STOP) cycle_counter <= cycle_counter + 1'b1;
     end
-end
 
-
-//
-// Progresses the next FSM state.
-always @(posedge clk) begin : p_fsm_state
-    if(!resetn) begin
-        fsm_state <= FSM_IDLE;
-    end else begin
-        fsm_state <= n_fsm_state;
+    always @(posedge clk) begin : p_fsm_state
+        if(!rst_n) fsm_state <= FSM_IDLE;
+        else fsm_state <= n_fsm_state;
     end
-end
 
-
-//
-// Responsible for updating the internal value of the rxd_reg.
-always @(posedge clk) begin : p_rxd_reg
-    if(!resetn) begin
-        rxd_reg     <= 1'b1;
-        rxd_reg_0   <= 1'b1;
-    end else if(uart_rx_en) begin
-        rxd_reg     <= rxd_reg_0;
-        rxd_reg_0   <= uart_rxd;
+    always @(posedge clk) begin : p_rxd_reg
+        if(!rst_n) begin
+            rxd_reg <= 1'b1;
+            rxd_reg_0 <= 1'b1;
+        end else if(uart_rx_en) begin
+            rxd_reg <= rxd_reg_0;
+            rxd_reg_0 <= uart_rxd;
+        end
     end
-end
-
-
 endmodule

--- a/rtl/uart_top.v
+++ b/rtl/uart_top.v
@@ -1,13 +1,6 @@
-`timescale 1ns/1ps
-// 
-// Module: uart_top (Upgraded Version by [yy] 8.31 17£º11)
-// Notes:
-// - This module keeps the original interface for seamless integration.
-// - It now implements register mapping for data and status access.
-// - It properly utilizes the uart_addr input.
-//
+`timescale 1ns / 1ps
+
 module uart_top (
-    // This interface is IDENTICAL to your team lead's original uart_top.v
     input               clk,
     input               rst_n,
     input   wire        uart_rxd,
@@ -20,102 +13,65 @@ module uart_top (
     input               uart_wen
 );
 
-    // --- Parameters (kept from the original files) ---
-    // IMPORTANT: Let's use 50MHz as it's a more common clock for FPGA peripherals.
-    // The top.v should provide a 50MHz clock to this 'clk' input.
     parameter CLK_HZ = 50_000_000; 
     parameter BIT_RATE = 9600;
     parameter PAYLOAD_BITS = 8;
 
-    // --- Internal wires connecting this wrapper to the RX/TX cores ---
     wire [PAYLOAD_BITS-1:0]  core_rx_data;
     wire                     core_rx_valid;
     wire                     core_tx_busy;
     
-    // -----------------------------------------------------------------
-    // 1. Address Decoding Logic (This is the main upgrade!)
-    //    We now use the 'uart_addr' to decide what the CPU wants to do.
-    // -----------------------------------------------------------------
-    // Define our register addresses (we only care about the lower bits)
     localparam ADDR_DATA_REG   = 32'h0;
     localparam ADDR_STATUS_REG = 32'h4;
 
     wire is_accessing_data_reg   = (uart_addr[11:0] == ADDR_DATA_REG[11:0]);
     wire is_accessing_status_reg = (uart_addr[11:0] == ADDR_STATUS_REG[11:0]);
 
-    // -----------------------------------------------------------------
-    // 2. Write Logic (Controlling the TX core)
-    // -----------------------------------------------------------------
-    // The CPU wants to send data if it's a write operation (wen=1),
-    // the address is the data register, and the transmitter is not busy.
     wire core_tx_en = uart_wen && is_accessing_data_reg && !core_tx_busy;
     wire [PAYLOAD_BITS-1:0] core_tx_data = uart_write_data[PAYLOAD_BITS-1:0];
     
-    // The rx_valid flag should be cleared after the CPU reads the data register.
     wire rx_data_read_clear = !uart_wen && is_accessing_data_reg;
 
-    // -----------------------------------------------------------------
-    // 3. Read Logic (Providing data back to the CPU)
-    // -----------------------------------------------------------------
-    // This is combinational logic, providing an immediate response,
-    // just like in the original design.
     reg [31:0] read_data_selection;
     always @(*) begin
-        if (is_accessing_data_reg) begin
-            // If CPU reads the data register, provide the last received byte.
-            read_data_selection = {24'b0, core_rx_data};
-        end else if (is_accessing_status_reg) begin
-            // If CPU reads the status register, provide the status.
-            // Bit 1: TX is ready (not busy)
-            // Bit 0: RX has valid data
-            read_data_selection = {30'b0, ~core_tx_busy, core_rx_valid};
-        end else begin
-            read_data_selection = 32'h0;
-        end
+        if (is_accessing_data_reg) read_data_selection = {24'b0, core_rx_data};
+        else if (is_accessing_status_reg) read_data_selection = {30'b0, ~core_tx_busy, core_rx_valid};
+        else read_data_selection = 32'h0;
     end
     
-    // The final read data is only driven if the CPU is NOT writing.
     assign uart_read_data = (!uart_wen) ? read_data_selection : 32'h0;
 
-    // -----------------------------------------------------------------
-    // 4. LED Logic (Kept from original, slightly improved)
-    // -----------------------------------------------------------------
     reg [PAYLOAD_BITS-1:0] led_reg;
     assign led = led_reg;
     
     always @(posedge clk) begin
-        if(!rst_n) begin
-            led_reg <= 8'hF0;
-        end else if(core_rx_valid) begin // When new data arrives
-            led_reg <= core_rx_data;
-        end else if(core_tx_en) begin    // When a new character is sent
-            led_reg <= core_tx_data;
-        end
+        if(!rst_n) led_reg <= 8'hF0;
+        else if(core_rx_valid) led_reg <= core_rx_data;
+        else if(core_tx_en) led_reg <= core_tx_data;
     end
 
-    // ------------------------------------------------------------------------- 
-    // 5. Instantiate the original RX and TX cores (No changes needed here)
-    // ------------------------------------------------------------------------- 
     uart_rx #(
-        .BIT_RATE(BIT_RATE),
-        .PAYLOAD_BITS(PAYLOAD_BITS),
-        .CLK_HZ  (CLK_HZ)
+        .BIT_RATE(BIT_RATE), .PAYLOAD_BITS(PAYLOAD_BITS), .CLK_HZ(CLK_HZ)
     ) i_uart_rx(
-        .clk          (clk),
-        .rst_n       (rst_n),
-        .clk(clk), .rst_n(rst_n), .uart_txd(uart_txd), .uart_tx_en(core_tx_en),
-        .uart_rxd     (uart_rxd),
-        .uart_rx_en   (1'b1),
+        .clk(clk),
+        .rst_n(rst_n),
+        .rx_data_read(rx_data_read_clear),
+        .uart_rxd(uart_rxd),
+        .uart_rx_en(1'b1),
         .uart_rx_break(),
         .uart_rx_valid(core_rx_valid),
-        .uart_rx_data (core_rx_data)
+        .uart_rx_data(core_rx_data)
     );
 
     uart_tx #(
         .BIT_RATE(BIT_RATE), .PAYLOAD_BITS(PAYLOAD_BITS), .CLK_HZ(CLK_HZ)
     ) i_uart_tx(
-        .clk(clk), .resetn(rst_n), .uart_txd(uart_txd), .uart_tx_en(core_tx_en),
-        .uart_tx_busy(core_tx_busy), .uart_tx_data(core_tx_data) 
+        .clk(clk),
+        .rst_n(rst_n),
+        .uart_txd(uart_txd),
+        .uart_tx_en(core_tx_en),
+        .uart_tx_busy(core_tx_busy),
+        .uart_tx_data(core_tx_data) 
     );
 
 endmodule

--- a/rtl/uart_tx.v
+++ b/rtl/uart_tx.v
@@ -126,7 +126,7 @@ end
 //
 // Increments the bit counter each time a new bit frame is sent.
 always @(posedge clk) begin : p_bit_counter
-    if(!rst_n) begin
+    if(rst_n) begin
         bit_counter <= 4'b0;
     end else if(fsm_state != FSM_SEND && fsm_state != FSM_STOP) begin
         bit_counter <= {COUNT_REG_LEN{1'b0}};


### PR DESCRIPTION
1.  **重构`uart_rx.v`**: 彻底修复了`rx_valid`信号为瞬时脉冲导致CPU无法捕获的问题。现在`rx_valid`为粘性信号，在数据被读取后才会被清除，确保了可靠的CPU-外设握手。
2.  **完善`uart_top.v`**: 在保持外部接口不变的前提下，内部逻辑已升级，可以正确地处理地址译码、状态查询和读写控制。
3.  **统一接口**：将所有模块的复位信号统一为低电平有效的`rst_n`，与团队标准保持一致。